### PR TITLE
Add RPM output to H_King_20A

### DIFF
--- a/SiLabs/H_King_20A.inc
+++ b/SiLabs/H_King_20A.inc
@@ -304,6 +304,8 @@ ENDM
 MACRO Stop_Adc
 ENDM
 MACRO Set_RPM_Out
+	setb    P2.DebugPin
 ENDM
 MACRO Clear_RPM_Out
+	clr     P2.DebugPin
 ENDM


### PR DESCRIPTION
Added RPM output pulse on P2.0
RPM output pulse appears on C2D - white wire of flash/program cable
