### PR TITLE
corrected the Mux_A and Mux_C pin out for MD-RX62H

### DIFF
--- a/SiLabs/MDRX62H.inc
+++ b/SiLabs/MDRX62H.inc
@@ -86,11 +86,11 @@ SIGNATURE_002			EQU	030h
 ;*********************  
 Rcp_In		EQU	7	;i
 Vref			EQU	6	;i
-Mux_A		EQU	5	;i
+Mux_C		EQU	5	;i
 ;			EQU	4	;i
 Mux_B		EQU	3	;i
 Comp_Com		EQU	2	;i
-Mux_C		EQU	1	;i
+Mux_A		EQU	1	;i
 Adc_Ip		EQU	0	;i
 
 P0_DIGITAL	EQU	NOT((1 SHL Mux_A)+(1 SHL Mux_B)+(1 SHL Mux_C)+(1 SHL Comp_Com)+(1 SHL Adc_Ip)+(1 SHL Vref))


### PR DESCRIPTION
pin out was incorrect, I switched Mux_A and Mux_C.

additionally, some more information.
- minimum throttle must be set to at least 1.176 ms for it to work
- the two round pads visible in the top corner in the picture of the MD-RX62H in the manual (BLHeli supported SiLabs ESCs.pdf) are used for programming: the upper pad connects to the MISO, the other to MOSI on the arduino nano. I don't know which is circled red and which is white normally...