### PR TITLE
Multishot @32khz Calibration fix

### DIFF
--- a/BLHeli_S SiLabs/BLHeli_S.asm
+++ b/BLHeli_S SiLabs/BLHeli_S.asm
@@ -1600,7 +1600,7 @@ beep_apwmfet_off:
 	jnb	ACC.0, beep_cpwmfet_off
 	CpwmFET_off		; CpwmFET off
 beep_cpwmfet_off:
-	mov	A, #150		; 25µs off
+	mov	A, #150		; 25Âµs off
 	djnz	ACC, $		
 	djnz	Temp2, beep_onoff
 	; Copy variable
@@ -3560,6 +3560,25 @@ ENDIF
 	subb	A, #10
 	jnc	($+4)
 	ajmp	validate_rcp_start
+	
+	; Setup timers for Multishot
+	mov	IT01CF, #RTX_PIN	; Route RCP input to INT0
+	mov	TCON, #11h		; Timer 0 run and INT0 edge triggered
+	mov	CKCON0, #04h		; Timer 0 clock is system clock
+	mov	TMOD, #09h		; Timer 0 set to 16bits and gated by INT0
+	; Setup interrupts for Multishot
+	setb	IE_ET0			; Enable timer 0 interrupts
+	clr	IE_ET1			; Disable timer 1 interrupts
+	clr	IE_EX1			; Disable int1 interrupts
+	; Test whether signal is Multishot
+	clr	Flags2.RCP_ONESHOT42
+	setb	Flags2.RCP_MULTISHOT			; Set Multishot flag
+	mov	Rcp_Outside_Range_Cnt, #0		; Reset out of range counter
+	call wait100ms						; Wait for new RC pulse
+	clr	C
+	mov	A, Rcp_Outside_Range_Cnt			; Check how many pulses were outside normal range ("900-2235us")
+	subb	A, #10
+	jc	validate_rcp_start
 
 	; Setup timers for DShot
 	mov	IT01CF, #(80h+(RTX_PIN SHL 4)+(RTX_PIN))	; Route RCP input to INT0/1, with INT1 inverted
@@ -3581,7 +3600,7 @@ ENDIF
 	mov	DShot_Pwm_Thr, #20				; Load DShot qualification pwm threshold (for DShot150)
 	mov	DShot_Frame_Length_Thr, #80		; Load DShot frame length criteria
 	; Test whether signal is DShot150
-	clr	Flags2.RCP_ONESHOT42
+	clr	Flags2.RCP_MULTISHOT
 	setb	Flags2.RCP_DSHOT
 	mov	Rcp_Outside_Range_Cnt, #0		; Reset out of range counter
 	call wait100ms						; Wait for new RC pulse
@@ -3626,26 +3645,7 @@ ENDIF
 	mov	A, Rcp_Outside_Range_Cnt			; Check if pulses were accepted
 	subb	A, #10
 	jc	validate_rcp_start
-
-	; Setup timers for Multishot
-	mov	IT01CF, #RTX_PIN	; Route RCP input to INT0
-	mov	TCON, #11h		; Timer 0 run and INT0 edge triggered
-	mov	CKCON0, #04h		; Timer 0 clock is system clock
-	mov	TMOD, #09h		; Timer 0 set to 16bits and gated by INT0
-	; Setup interrupts for Multishot
-	setb	IE_ET0			; Enable timer 0 interrupts
-	clr	IE_ET1			; Disable timer 1 interrupts
-	clr	IE_EX1			; Disable int1 interrupts
-	; Test whether signal is Multishot
-	clr	Flags2.RCP_DSHOT
-	setb	Flags2.RCP_MULTISHOT			; Set Multishot flag
-	mov	Rcp_Outside_Range_Cnt, #0		; Reset out of range counter
-	call wait100ms						; Wait for new RC pulse
-	clr	C
-	mov	A, Rcp_Outside_Range_Cnt			; Check how many pulses were outside normal range ("900-2235us")
-	subb	A, #10
-	jc	validate_rcp_start
-
+	
 	ajmp	init_no_signal
 
 validate_rcp_start:


### PR DESCRIPTION
This change fixes the issue with Throttle Calibration failing when running Multishot at 32khz pwm rate.